### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/rails.yml
+++ b/.github/workflows/rails.yml
@@ -5,6 +5,8 @@
 # This workflow will install a prebuilt Ruby version, install dependencies, and
 # run tests and linters.
 name: "Ruby on Rails CI"
+permissions:
+  contents: read
 on: push
 jobs:
   rspec:


### PR DESCRIPTION
Potential fix for [https://github.com/collective-interchange-coop/newcomer-navigator-nl/security/code-scanning/5](https://github.com/collective-interchange-coop/newcomer-navigator-nl/security/code-scanning/5)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will define the minimal permissions required for the workflow. Since the workflow does not seem to require write access, we will set `contents: read` as the default permission. This ensures that the `GITHUB_TOKEN` has only read access to the repository contents, reducing the risk of unintended write operations.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
