### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/greetings.yml
+++ b/.github/workflows/greetings.yml
@@ -2,6 +2,11 @@ name: Greetings
 
 on: [pull_request, issues]
 
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
 jobs:
   greeting:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/collective-interchange-coop/newcomer-navigator-nl/security/code-scanning/2](https://github.com/collective-interchange-coop/newcomer-navigator-nl/security/code-scanning/2)

To fix the issue, add a `permissions` block to the workflow file. This block should specify the minimal permissions required for the workflow to function correctly. Since the workflow interacts with issues and pull requests, the permissions should include `issues: write` and `pull-requests: write`. The `contents: read` permission is also necessary for basic repository access.

The `permissions` block can be added at the root level of the workflow file to apply to all jobs, or within the specific job (`greeting`) to limit permissions for that job only. In this case, adding it at the root level is recommended for simplicity.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
