### PR TITLE
Fix download prefetch tracking

### DIFF
--- a/app/views/resources/_resource.html.erb
+++ b/app/views/resources/_resource.html.erb
@@ -31,7 +31,10 @@
         <% end %>
       <% elsif resource.is_a?(Resource::Document) && resource.file.attached? %>
         <% if policy(resource).download? %>
-          <%= link_to download_resource_path(resource), class: "btn btn-outline-primary btn-sm", download: resource.file.filename.to_s do %>
+          <%= link_to download_resource_path(resource),
+                      class: "btn btn-outline-primary btn-sm",
+                      download: resource.file.filename.to_s,
+                      data: { turbo_prefetch: false } do %>
             <i class="fas fa-download"></i> <%= t('globals.download') %>
           <% end %>
         <% end %>


### PR DESCRIPTION
## Summary
- avoid metrics job when turbo prefetches the download
- disable turbo prefetch on download links

## Testing
- `bundle exec rspec`

------
https://chatgpt.com/codex/tasks/task_e_688ccde1cf18832190c1d0ef40f04b99